### PR TITLE
Feature: Persist transaction query

### DIFF
--- a/src/app/bridge/Send/index.tsx
+++ b/src/app/bridge/Send/index.tsx
@@ -18,7 +18,6 @@ import useBridgeStore, { TransactionType } from "@/stores/bridgeStore"
 import useTxStore from "@/stores/txStore"
 import { generateExploreLink, pollAllTransactionStatuses } from "@/utils"
 
-
 import TxHistoryTable from "../TxHistoryDialog/TxHistoryTable"
 import Deposit from "./Deposit"
 import Withdraw from "./Withdraw"
@@ -152,7 +151,6 @@ const Send = () => {
     changeIsNetworkCorrect(networkCorrect)
   }, [fromNetwork, txType, withDrawStep, chainId])
 
-
   useEffect(() => {
     if (!walletCurrentAddress || !networksAndSigners) {
       return
@@ -166,7 +164,6 @@ const Send = () => {
   }, [walletCurrentAddress, networksAndSigners])
 
   const handleChangeTransactionType = (e, newValue) => {
-
     changeTxType(newValue)
     // Clone current search params
     const params = new URLSearchParams(searchParams)

--- a/src/app/bridge/Send/index.tsx
+++ b/src/app/bridge/Send/index.tsx
@@ -153,7 +153,7 @@ const Send = () => {
     }
     const storedPendingTxs = JSON.parse(localStorage.getItem("pendingTransactions") || "{}")
 
-    if (walletCurrentAddress && networksAndSigners && Object.keys(storedPendingTxs).length > 0) {
+    if (Object.keys(storedPendingTxs).length > 0) {
       const interval = pollAllTransactionStatuses(walletCurrentAddress, networksAndSigners, updateTransaction)
       return () => clearInterval(interval)
     }

--- a/src/app/bridge/Send/index.tsx
+++ b/src/app/bridge/Send/index.tsx
@@ -10,10 +10,12 @@ import Alert from "@/components/Alert"
 import Link from "@/components/Link"
 import { CHAIN_ID, ETH_SYMBOL, NETWORKS } from "@/constants"
 import { BRIDGE_TOKEN } from "@/constants/searchParamsKey"
+import { useBridgeContext } from "@/contexts/BridgeContextProvider"
 import { useRainbowContext } from "@/contexts/RainbowProvider"
 import useBatchBridgeStore, { DepositBatchMode } from "@/stores/batchBridgeStore"
 import useBridgeStore from "@/stores/bridgeStore"
-import { generateExploreLink } from "@/utils"
+import useTxStore from "@/stores/txStore"
+import { generateExploreLink, pollAllTransactionStatuses } from "@/utils"
 
 import TxHistoryTable from "../TxHistoryDialog/TxHistoryTable"
 import Deposit from "./Deposit"
@@ -108,7 +110,7 @@ const useStyles = makeStyles()(theme => ({
 
 const Send = () => {
   const { classes, cx } = useStyles()
-  const { chainId } = useRainbowContext()
+  const { chainId, walletCurrentAddress } = useRainbowContext()
   const {
     txType,
     txResult,
@@ -123,7 +125,9 @@ const Send = () => {
     changeIsNetworkCorrect,
   } = useBridgeStore()
 
+  const { networksAndSigners } = useBridgeContext()
   const { depositBatchMode } = useBatchBridgeStore()
+  const { updateTransaction } = useTxStore()
 
   const searchParams = useSearchParams()
   const token = searchParams.get(BRIDGE_TOKEN)
@@ -142,6 +146,18 @@ const Send = () => {
     }
     changeIsNetworkCorrect(networkCorrect)
   }, [fromNetwork, txType, withDrawStep, chainId])
+
+  useEffect(() => {
+    if (!walletCurrentAddress || !networksAndSigners) {
+      return
+    }
+    const storedPendingTxs = JSON.parse(localStorage.getItem("pendingTransactions") || "{}")
+
+    if (walletCurrentAddress && networksAndSigners && Object.keys(storedPendingTxs).length > 0) {
+      const interval = pollAllTransactionStatuses(walletCurrentAddress, networksAndSigners, updateTransaction)
+      return () => clearInterval(interval)
+    }
+  }, [walletCurrentAddress, networksAndSigners])
 
   const handleChange = (e, newValue) => {
     changeTxType(newValue)

--- a/src/constants/networks.ts
+++ b/src/constants/networks.ts
@@ -2,7 +2,6 @@ import MainnetSvg from "@/assets/svgs/bridge/network-mainnet.svg"
 import ETHSvg from "@/assets/svgs/bridge/network-mainnet.svg?url"
 import T1Svg from "@/assets/svgs/bridge/network-t1.svg"
 import USDTSvg from "@/assets/svgs/bridge/usdt.svg?url"
-import { isMainnet, isSepolia } from "@/utils"
 
 import { CHAIN_ID, ETH_SYMBOL, EXPLORER_URL, L1_NAME, L2_NAME, RPC_URL, USDT_SYMBOL, WETH_SYMBOL } from "./common"
 

--- a/src/hooks/useSendTransaction.ts
+++ b/src/hooks/useSendTransaction.ts
@@ -9,7 +9,7 @@ import useBatchBridgeStore, { BridgeSummaryType, DepositBatchMode } from "@/stor
 import useBridgeStore from "@/stores/bridgeStore"
 import useTxStore from "@/stores/txStore"
 import { isValidOffsetTime } from "@/stores/utils"
-import { amountToBN, isSepolia, sentryDebug } from "@/utils"
+import { amountToBN, isSepolia, pollAllTransactionStatuses, sentryDebug } from "@/utils"
 
 import useGasFee from "./useGasFee"
 
@@ -155,6 +155,7 @@ export function useSendTransaction(props) {
       updateTransaction(walletCurrentAddress, tx.hash, updateOpts)
       return
     }
+
     addTransaction(walletCurrentAddress, {
       hash: tx.hash,
       amount: parsedAmount.toString(),
@@ -164,6 +165,7 @@ export function useSendTransaction(props) {
       initiatedAt: Math.floor(new Date().getTime() / 1000),
       txStatus: TX_STATUS.Unknown,
     })
+    pollAllTransactionStatuses(walletCurrentAddress, networksAndSigners, updateTransaction)
   }
 
   const depositETH = async () => {

--- a/src/stores/txStore.ts
+++ b/src/stores/txStore.ts
@@ -26,6 +26,14 @@ const useTxStore = create<TxStore>()(
           txList = [...txList]
         }
         txList.unshift(newTx)
+
+        // Save transaction hash in localStorage
+        const storedPendingTxs = JSON.parse(localStorage.getItem("pendingTransactions") || "{}")
+        if (newTx?.hash) {
+          storedPendingTxs[newTx.hash] = walletAddress
+          localStorage.setItem("pendingTransactions", JSON.stringify(storedPendingTxs))
+        }
+
         set({
           frontTransactions: { ...frontTransactions, [walletAddress]: txList },
         })

--- a/src/utils/ethereum.ts
+++ b/src/utils/ethereum.ts
@@ -1,5 +1,5 @@
 import { getWalletClient, switchChain } from "@wagmi/core"
-import { ethers, isError } from "ethers"
+import { isError } from "ethers"
 import { isNumber } from "lodash"
 
 import { CHAIN_ID, TX_STATUS } from "@/constants"

--- a/src/utils/ethereum.ts
+++ b/src/utils/ethereum.ts
@@ -34,57 +34,81 @@ export const isUserRejected = error => {
   return isError(error, "ACTION_REJECTED")
 }
 
+const getFrontTransactions = () => {
+  try {
+    return useTxStore.getState().frontTransactions
+  } catch (error) {
+    console.error("Error fetching frontTransactions:", error)
+    return {}
+  }
+}
+
+const fetchTransactionStatus = async (transactionHash, provider) => {
+  try {
+    return await provider.getTransactionReceipt(transactionHash)
+  } catch (error) {
+    console.error(`Error fetching transaction status for ${transactionHash}:`, error)
+    return null
+  }
+}
+
+const removePendingTransaction = transactionHash => {
+  const storedPendingTxs = JSON.parse(localStorage.getItem("pendingTransactions") || "{}")
+
+  if (!storedPendingTxs[transactionHash]) return storedPendingTxs // No change needed
+
+  delete storedPendingTxs[transactionHash]
+
+  // Only update localStorage if there are still pending transactions
+  if (Object.keys(storedPendingTxs).length > 0) {
+    localStorage.setItem("pendingTransactions", JSON.stringify(storedPendingTxs))
+  } else {
+    // Remove the key completely if empty
+    localStorage.removeItem("pendingTransactions")
+  }
+
+  // Return updated transactions for further checks
+  return storedPendingTxs
+}
+
 export const pollAllTransactionStatuses = (walletCurrentAddress, networksAndSigners, updateTransaction) => {
-  let pollingActive = true
-
   const interval = setInterval(async () => {
-    if (!pollingActive) {
-      clearInterval(interval)
-      return
-    }
+    let storedPendingTxs = JSON.parse(localStorage.getItem("pendingTransactions") || "{}")
 
-    const storedPendingTxs = JSON.parse(localStorage.getItem("pendingTransactions") || "{}")
-
-    // if no pending transactions
+    // Stop polling if no pending transactions
     if (Object.keys(storedPendingTxs).length === 0) {
       clearInterval(interval)
       return
     }
 
-    const { frontTransactions } = useTxStore.getState()
-
-    let txList = frontTransactions[walletCurrentAddress] ?? []
+    const frontTransactions = getFrontTransactions()
+    const txList = frontTransactions[walletCurrentAddress] ?? []
 
     for (const transactionHash of Object.keys(storedPendingTxs)) {
       const tx = txList.find(txItem => txItem.hash === transactionHash)
-      if (!tx) continue // Skip if transaction not found
+      // Skip if transaction not found
+      if (!tx) continue
 
       const provider = networksAndSigners[tx.isL1 ? CHAIN_ID.L1 : CHAIN_ID.L2].provider
+      const receipt = await fetchTransactionStatus(transactionHash, provider)
 
-      try {
-        const receipt = await provider.getTransactionReceipt(transactionHash)
+      if (receipt?.status === 1) {
+        // Remove from localStorage and update transaction status
+        storedPendingTxs = removePendingTransaction(transactionHash)
 
-        if (receipt && receipt.status === 1) {
-          // Remove from localStorage
-          delete storedPendingTxs[transactionHash]
-          localStorage.setItem("pendingTransactions", JSON.stringify(storedPendingTxs))
-
-          // Update transaction status
-          updateTransaction(walletCurrentAddress, tx.hash, {
-            fromBlockNumber: receipt.blockNumber,
-            txStatus: TX_STATUS.Sent,
-          })
-        }
-      } catch (error) {
-        console.error(`Error fetching transaction status for ${transactionHash}:`, error)
+        updateTransaction(walletCurrentAddress, tx.hash, {
+          fromBlockNumber: receipt.blockNumber,
+          txStatus: TX_STATUS.Sent,
+        })
       }
     }
 
-    // If no more transactions are pending, stop polling
+    // Stop polling if no more pending transactions
     if (Object.keys(storedPendingTxs).length === 0) {
       clearInterval(interval)
     }
-  }, 5000) // Poll every 5 seconds
+    // Poll every 5 seconds
+  }, 5000)
 
   return interval
 }

--- a/src/utils/ethereum.ts
+++ b/src/utils/ethereum.ts
@@ -1,9 +1,11 @@
 import { getWalletClient, switchChain } from "@wagmi/core"
-import { isError } from "ethers"
+import { ethers, isError } from "ethers"
 import { isNumber } from "lodash"
 
+import { CHAIN_ID, TX_STATUS } from "@/constants"
 import { defaultConfig } from "@/contexts/RainbowProvider"
 import { DepositBatchMode } from "@/stores/batchBridgeStore"
+import useTxStore from "@/stores/txStore"
 
 export const switchNetwork = async (chainId: number) => {
   const walletClient = await getWalletClient(defaultConfig)
@@ -30,4 +32,59 @@ export const checkApproved = (needApproval, mode: DepositBatchMode) => {
 
 export const isUserRejected = error => {
   return isError(error, "ACTION_REJECTED")
+}
+
+export const pollAllTransactionStatuses = (walletCurrentAddress, networksAndSigners, updateTransaction) => {
+  let pollingActive = true
+
+  const interval = setInterval(async () => {
+    if (!pollingActive) {
+      clearInterval(interval)
+      return
+    }
+
+    const storedPendingTxs = JSON.parse(localStorage.getItem("pendingTransactions") || "{}")
+
+    // if no pending transactions
+    if (Object.keys(storedPendingTxs).length === 0) {
+      clearInterval(interval)
+      return
+    }
+
+    const { frontTransactions } = useTxStore.getState()
+
+    let txList = frontTransactions[walletCurrentAddress] ?? []
+
+    for (const transactionHash of Object.keys(storedPendingTxs)) {
+      const tx = txList.find(txItem => txItem.hash === transactionHash)
+      if (!tx) continue // Skip if transaction not found
+
+      const provider = networksAndSigners[tx.isL1 ? CHAIN_ID.L1 : CHAIN_ID.L2].provider
+
+      try {
+        const receipt = await provider.getTransactionReceipt(transactionHash)
+
+        if (receipt && receipt.status === 1) {
+          // Remove from localStorage
+          delete storedPendingTxs[transactionHash]
+          localStorage.setItem("pendingTransactions", JSON.stringify(storedPendingTxs))
+
+          // Update transaction status
+          updateTransaction(walletCurrentAddress, tx.hash, {
+            fromBlockNumber: receipt.blockNumber,
+            txStatus: TX_STATUS.Sent,
+          })
+        }
+      } catch (error) {
+        console.error(`Error fetching transaction status for ${transactionHash}:`, error)
+      }
+    }
+
+    // If no more transactions are pending, stop polling
+    if (Object.keys(storedPendingTxs).length === 0) {
+      clearInterval(interval)
+    }
+  }, 5000) // Poll every 5 seconds
+
+  return interval
 }


### PR DESCRIPTION
## PR Summary
Persist Transaction Query by storing all pending transactions into local storage.
If a page refreshes, we will query all pending transactions and get its state


https://github.com/user-attachments/assets/9031d6d5-8db1-4b71-bf1f-2227b69dc6a9


---

## Checklist

- [ ] There are breaking changes
- [ ] I've added/changed/removed ENV variable(s)
- [x] I checked whether I should update the docs and did so by updating `/docs`

---

## Description

[comment]: # (Please provide a more detailed description of your pull request here, explaining the changes made and the reasoning behind them)

