### PR TITLE
fix: change annoucement banner to hackathon

### DIFF
--- a/src/components/Header/announcement.tsx
+++ b/src/components/Header/announcement.tsx
@@ -15,9 +15,9 @@ const Announcement = () => {
     if (isMainnet && isHome) {
       return (
         <>
-          Join Scroll Open: Build the Future of the Open Economy{" "}
+          Hack on 𝚝𝟷 as part of ETHGlobal Trifecta this weekend{" "}
           <div className="inline-block w-[5px] h-[5px] rounded-full bg-current mx-[20px] align-middle"></div>
-          Jan 27 - March 17
+          20 March - 23 March
           <div className="inline-block w-[5px] h-[5px] rounded-full bg-current mx-[20px] align-middle"></div>
         </>
       )
@@ -27,7 +27,7 @@ const Announcement = () => {
 
   const rightHref = useMemo(() => {
     if (isMainnet && isHome) {
-      return "https://open.scroll.io"
+      return "https://x.com/t1protocol/status/1901966613680689163"
     }
     return ""
   }, [isMainnet, isHome])


### PR DESCRIPTION
## PR Summary
Change the scroll banner to announce t1's hackathon

## Checklist

- [x] I listed any breaking changes below:
      
- [x] I listed any env variable additions/changes/removals below:
      
- [x] I checked whether I should update the docs in https://github.com/t1protocol/docs and if so, added PR link below:
      
- [x] I updated the notion task tracker's status and added link to this PR there