### PR TITLE
fix: made banner link open a new tab

### DIFF
--- a/src/components/Header/announcement.tsx
+++ b/src/components/Header/announcement.tsx
@@ -33,7 +33,7 @@ const Announcement = () => {
   }, [isMainnet, isHome])
 
   return displayAnnouncement && announcementContent ? (
-    <a href={rightHref} rel="noopener noreferrer" className="mb-[1.6rem]">
+    <a href={rightHref} target="_blank" rel="noopener noreferrer" className="mb-[1.6rem]">
       <Box
         sx={{
           backgroundColor: theme => (isMainnet ? theme.palette.common.white : theme.palette.primary.main),


### PR DESCRIPTION
## PR Summary
banner link should open a new tab


## Checklist

- [x] I listed any breaking changes below:
      
- [x] I listed any env variable additions/changes/removals below:
      
- [x] I checked whether I should update the docs in https://github.com/t1protocol/docs and if so, added PR link below:
      
- [x] I updated the notion task tracker's status and added link to this PR there