### PR TITLE
Fix: Align Bridge names to t1 v{CHAIN_VERSION}

### DIFF
--- a/src/app/portal/WalletConfig.tsx
+++ b/src/app/portal/WalletConfig.tsx
@@ -94,7 +94,7 @@ const WalletConfig = () => {
               justifyContent="space-between"
               sx={{ width: ["100%", "60rem"], border: "1px solid #DADADA", borderRadius: "10rem", p: ["1.2rem 1.6rem", "1.2rem 2.2rem"] }}
             >
-              <Typography>{item.name}</Typography>
+              <Typography>{item.chainVersion}</Typography>
               {walletName ? (
                 <AddNetworkButton chainId={item.chainId} onReadd={handleReadd} />
               ) : (

--- a/src/components/WalletToolkit/NetworkSelect.tsx
+++ b/src/components/WalletToolkit/NetworkSelect.tsx
@@ -107,12 +107,12 @@ const NetworkSelect = props => {
         </ButtonBase>
       )}
       <Menu anchorEl={anchorEl} open={open} onClose={handleClose} TransitionComponent={Fade} classes={{ paper: classes.paper, list: classes.list }}>
-        {NETWORKS.map(({ icon, name, chainId }) => (
+        {NETWORKS.map(({ icon, name, chainVersion, chainId }) => (
           <MenuItem key={name} classes={{ root: classes.listItem }} onClick={() => handleSwitchNetwork(chainId)}>
             <ListItemIcon classes={{ root: classes.listItemIcon }}>
               <SvgIcon sx={{ fontSize: "2.4rem" }} component={icon} inheritViewBox></SvgIcon>
             </ListItemIcon>
-            <ListItemText classes={{ primary: classes.listItemText }}>{name}</ListItemText>
+            <ListItemText classes={{ primary: classes.listItemText }}>{chainVersion}</ListItemText>
           </MenuItem>
         ))}
       </Menu>

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -9,6 +9,7 @@ export const L1_NAME = `Ethereum ${isSepolia ? "Sepolia" : process.env.NEXT_PUBL
 
 export const L2_DEVNET_NAME = process.env.NEXT_PUBLIC_SCROLL_ENVIRONMENT === "Sepolia" ? process.env.NEXT_PUBLIC_T1_ENVIRONMENT : "Testnet"
 export const L2_NAME = `𝚝𝟷 ${isMainnet ? "" : L2_DEVNET_NAME}`
+export const L2_CHAIN_NAME = `𝚝𝟷 v${process.env.NEXT_PUBLIC_CHAIN_VERSION}`
 
 export const CHAIN_ID = {
   L1: parseInt(process.env.NEXT_PUBLIC_CHAIN_ID_L1),

--- a/src/constants/networks.ts
+++ b/src/constants/networks.ts
@@ -3,7 +3,7 @@ import ETHSvg from "@/assets/svgs/bridge/network-mainnet.svg?url"
 import T1Svg from "@/assets/svgs/bridge/network-t1.svg"
 import USDTSvg from "@/assets/svgs/bridge/usdt.svg?url"
 
-import { CHAIN_ID, ETH_SYMBOL, EXPLORER_URL, L1_NAME, L2_NAME, RPC_URL, USDT_SYMBOL, WETH_SYMBOL } from "./common"
+import { CHAIN_ID, ETH_SYMBOL, EXPLORER_URL, L1_NAME, L2_CHAIN_NAME, RPC_URL, USDT_SYMBOL, WETH_SYMBOL } from "./common"
 
 export const NETWORKS: Network[] = [
   {
@@ -17,7 +17,7 @@ export const NETWORKS: Network[] = [
     isL1: true,
   },
   {
-    name: L2_NAME,
+    name: L2_CHAIN_NAME,
     slug: "layer2",
     icon: T1Svg,
     rpcUrl: RPC_URL.L2,

--- a/src/constants/networks.ts
+++ b/src/constants/networks.ts
@@ -3,11 +3,12 @@ import ETHSvg from "@/assets/svgs/bridge/network-mainnet.svg?url"
 import T1Svg from "@/assets/svgs/bridge/network-t1.svg"
 import USDTSvg from "@/assets/svgs/bridge/usdt.svg?url"
 
-import { CHAIN_ID, ETH_SYMBOL, EXPLORER_URL, L1_NAME, L2_CHAIN_NAME, RPC_URL, USDT_SYMBOL, WETH_SYMBOL } from "./common"
+import { CHAIN_ID, ETH_SYMBOL, EXPLORER_URL, L1_NAME, L2_CHAIN_NAME, L2_NAME, RPC_URL, USDT_SYMBOL, WETH_SYMBOL } from "./common"
 
 export const NETWORKS: Network[] = [
   {
     name: L1_NAME,
+    chainVersion: L1_NAME,
     slug: "layer1",
     icon: MainnetSvg,
     rpcUrl: RPC_URL.L1,
@@ -17,7 +18,8 @@ export const NETWORKS: Network[] = [
     isL1: true,
   },
   {
-    name: L2_CHAIN_NAME,
+    name: L2_NAME,
+    chainVersion: L2_CHAIN_NAME,
     slug: "layer2",
     icon: T1Svg,
     rpcUrl: RPC_URL.L2,

--- a/src/contexts/PriceFeeProvider.tsx
+++ b/src/contexts/PriceFeeProvider.tsx
@@ -121,7 +121,7 @@ export const PriceFeeProvider = ({ children }) => {
   const [gasLimit, setGasLimit] = useState(BigInt(0))
   const [gasPrice, setGasPrice] = useState(BigInt(0))
   const [errorMessage, setErrorMessage] = useState("")
-  console.log(gasLimit)
+
   const fetchData = async () => {
     const { provider } = networksAndSigners[CHAIN_ID.L2]
     if (provider) {

--- a/src/contexts/PriceFeeProvider.tsx
+++ b/src/contexts/PriceFeeProvider.tsx
@@ -121,7 +121,7 @@ export const PriceFeeProvider = ({ children }) => {
   const [gasLimit, setGasLimit] = useState(BigInt(0))
   const [gasPrice, setGasPrice] = useState(BigInt(0))
   const [errorMessage, setErrorMessage] = useState("")
-
+  console.log(gasLimit)
   const fetchData = async () => {
     const { provider } = networksAndSigners[CHAIN_ID.L2]
     if (provider) {

--- a/src/contexts/t1/chain.ts
+++ b/src/contexts/t1/chain.ts
@@ -2,7 +2,7 @@ import { defineChain } from "viem"
 
 export const t1_devnet = /*#__PURE__*/ defineChain({
   id: Number(process.env.NEXT_PUBLIC_CHAIN_ID_L2),
-  name: `t1 ${process.env.NEXT_PUBLIC_CHAIN_VERSION}`,
+  name: `t1 v${process.env.NEXT_PUBLIC_CHAIN_VERSION}`,
   nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
   rpcUrls: {
     default: {

--- a/src/contexts/t1/chain.ts
+++ b/src/contexts/t1/chain.ts
@@ -2,7 +2,7 @@ import { defineChain } from "viem"
 
 export const t1_devnet = /*#__PURE__*/ defineChain({
   id: Number(process.env.NEXT_PUBLIC_CHAIN_ID_L2),
-  name: "𝚝1 v0.0.6",
+  name: `t1 ${process.env.NEXT_PUBLIC_CHAIN_VERSION}`,
   nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
   rpcUrls: {
     default: {


### PR DESCRIPTION
## PR Summary

Align Bridge names to `t1 v${CHAIN_VERSION}
<img width="1076" alt="Screenshot 2025-03-28 at 4 21 24 PM" src="https://github.com/user-attachments/assets/91b3d1c1-3727-49c1-b355-7d52930e4a87" />
<img width="359" alt="Screenshot 2025-03-28 at 4 22 35 PM" src="https://github.com/user-attachments/assets/da5344c5-9dca-4dda-afc8-6f05b4ac1130" />


## Checklist

- [x] I listed any breaking changes below:
      
- [x] I listed any env variable additions/changes/removals below:
      
- [x] I checked whether I should update the docs in https://github.com/t1protocol/docs and if so, added PR link below:
      
- [x] I updated the notion task tracker's status and added link to this PR there