### PR TITLE
Fix: Added degraded performance banner

### DIFF
--- a/src/components/Header/announcement.tsx
+++ b/src/components/Header/announcement.tsx
@@ -7,28 +7,20 @@ import { Box } from "@mui/material"
 const Announcement = () => {
   const displayAnnouncement = true
   const pathname = usePathname()
-  const isHome = pathname === "/"
 
   const announcementContent = useMemo(() => {
-    if (isHome) {
-      return (
-        <>
-          Hack on 𝚝𝟷 as part of ETHGlobal Trifecta this weekend{" "}
-          <div className="inline-block w-[5px] h-[5px] rounded-full bg-current mx-[20px] align-middle"></div>
-          20 March - 23 March
-          <div className="inline-block w-[5px] h-[5px] rounded-full bg-current mx-[20px] align-middle"></div>
-        </>
-      )
-    }
-    return null
-  }, [isHome])
+    return (
+      <>
+        Degraded performance due to high volume <div className="inline-block w-[5px] h-[5px] rounded-full bg-current mx-[20px] align-middle"></div>
+        Check Status Here
+        <div className="inline-block w-[5px] h-[5px] rounded-full bg-current mx-[20px] align-middle"></div>
+      </>
+    )
+  }, [])
 
   const rightHref = useMemo(() => {
-    if (isHome) {
-      return "https://x.com/t1protocol/status/1901966613680689163"
-    }
-    return ""
-  }, [isHome])
+    return "https://t1protocol.statuspage.io/"
+  }, [])
 
   return displayAnnouncement && announcementContent ? (
     <a href={rightHref} target="_blank" rel="noopener noreferrer" className="mb-[1.6rem]">

--- a/src/components/Header/desktop_header.tsx
+++ b/src/components/Header/desktop_header.tsx
@@ -289,7 +289,7 @@ const DesktopHeader = ({ currentMenu }) => {
         setIsHover(false)
       }}
     >
-      {/* <Announcement /> */}
+      <Announcement />
       <Container>
         <HeaderContainer>
           <ScrollLink href="/" className="flex">

--- a/src/components/Header/mobile_header.tsx
+++ b/src/components/Header/mobile_header.tsx
@@ -170,7 +170,7 @@ const MobileHeader = ({ currentMenu }) => {
       className={open ? "active" : ""}
       sx={{ backgroundColor: navbarBg && !open ? `themeBackground.${navbarBg}` : dark ? "themeBackground.dark" : "themeBackground.light" }}
     >
-      {/* <Announcement /> */}
+      <Announcement />
       <NavStack direction="row" justifyContent="space-between" alignItems="center">
         <Link href="/" className="flex">
           <Box onClick={() => toggleDrawer(false)} style={{ display: "flex" }}>


### PR DESCRIPTION
## PR Summary
Add banner to let users know about degraded performance

<img width="1469" alt="Screenshot 2025-04-17 at 4 28 59 PM" src="https://github.com/user-attachments/assets/9347a51f-23eb-42a1-a566-519e718cb8b3" />

## Checklist

- [x] I listed any breaking changes below:
      
- [x] I listed any env variable additions/changes/removals below:
      
- [x] I checked whether I should update the docs in https://github.com/t1protocol/docs and if so, added PR link below:
      
- [x] I updated the notion task tracker's status and added link to this PR there